### PR TITLE
#10 - Netlify F5 KO

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
-> Création du fichier netlify.toml pour fixer le problème d'erreur 404 en cas de rechargement de page pour un renvoie vers index.html